### PR TITLE
enhance tableau-desktop info

### DIFF
--- a/automatic/Tableau-Desktop/tableau-desktop.nuspec
+++ b/automatic/Tableau-Desktop/tableau-desktop.nuspec
@@ -19,7 +19,7 @@ A market-leading choice for modern business intelligence, the Tableau analytics 
 Driven to help people see and understand data, Tableau is designed to put the user first -- whether they’re an analyst, data scientist, student, teacher, executive, or business user. From connection through collaboration, Tableau is the most powerful, secure, and flexible end-to-end analytics platform.
 
 ## Install options
-The Tableau Desktop installer has a lot of optional properties that can be utilized with the `--installarguments` (`--ia`) switch.  [A full list of options can be found here](https://help.tableau.com/current/desktopdeploy/en-us/desktop_deploy_automate.htm#installer_properties).  Common properties:
+The Tableau Desktop installer has a lot of optional properties that can be utilized with the `--installarguments` (`--ia`) switch.  [A full list of options can be found here](https://help.tableau.com/current/desktopdeploy/en-us/desktop_deploy_automate.htm#installer-properties).  Common properties:
 
 * `ACTIVATE_KEY="(ProductKey)"` - For machine-based licenses
 * `ACTIVATIONSERVER="(ActivationServer)"` - For login-based licenses

--- a/automatic/Tableau-Desktop/tableau-desktop.nuspec
+++ b/automatic/Tableau-Desktop/tableau-desktop.nuspec
@@ -12,11 +12,42 @@
     <copyright>© 2003-2020 Tableau Software, LLC, A Salesforce Company. All Rights Reserved.</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>tableau data visualization charts business intelligence</tags>
-    <description>Tableau Desktop is data visualization software that lets you see and understand data in minutes. With other Tableau products, it comprises a complete business intelligence software solution.</description>
+    <description>Tableau Desktop is data visualization software that lets you see and understand data in minutes. With other Tableau products, it comprises a complete business intelligence software solution.
+
+A market-leading choice for modern business intelligence, the Tableau analytics platform makes it easier for people to explore and manage data, and faster to discover and share insights that can change businesses and the world.
+
+Driven to help people see and understand data, Tableau is designed to put the user first -- whether they’re an analyst, data scientist, student, teacher, executive, or business user. From connection through collaboration, Tableau is the most powerful, secure, and flexible end-to-end analytics platform.
+
+## Install options
+The Tableau Desktop installer has a lot of optional properties that can be utilized with the `--installarguments` (`--ia`) switch.  [A full list of options can be found here](https://help.tableau.com/current/desktopdeploy/en-us/desktop_deploy_automate.htm#installer_properties).  Common properties:
+
+* `ACTIVATE_KEY="(ProductKey)"` - For machine-based licenses
+* `ACTIVATIONSERVER="(ActivationServer)"` - For login-based licenses
+* `AUTOUPDATE=0` - To disable the default setting
+* `SENDTELEMETRY=0` - To disable the default setting
+* `DESKTOPSHORTCUT=0` - To prevent the default action
+* `STARTMENUSHORTCUT=0` - To prevent the default action
+* `REMOVEINSTALLEDAPP=1` - To remove previous versions.  Without this, previous versions and drivers will remain and Chocolatey will be unable to remove them.
+* `DATABASEDRIVERS=0` - To skip the default installation of included ODBC drivers.  These are only required for connecting to their respective database types and are also available independently as Chocolatey packages:
+   * [Microsoft® ODBC Driver for SQL Server](https://community.chocolatey.org/packages/sqlserver-odbcdriver)
+   * [PostgreSQL ODBC Driver](https://community.chocolatey.org/packages/psqlodbc/)
+   * [Amazon Redshift ODBC Driver](https://community.chocolatey.org/packages/redshift-odbc) 
+
+   ([Other Tableau database drivers can be found here.](https://www.tableau.com/support/drivers))
+
+##### Example install
+`choco install tableau-desktop --ia '"DESKTOPSHORTCUT=0 REMOVEINSTALLEDAPP=1"'`
+
+## Uninstall options
+By default, this package will not deactivate any product key during uninstall.  If you want to deactivate the product key, use the `--installarguments` (`--ia`) switch with the `RECLAIMLICENSE=1` option.
+
+##### Example uninstall
+`choco uninstall tableau-desktop --ia '"RECLAIMLICENSE=1"'`
+</description>
     <summary>Tableau Desktop is data visualization software that lets you see and understand data in minutes. With other Tableau products, it comprises a complete business intelligence software solution.</summary>
     <iconUrl>https://cdn.staticaly.com/gh/meek2100/chocolatey-packages/master/icons/tableau.png</iconUrl>
     <docsUrl>https://www.tableau.com/support/desktop</docsUrl>
-    <licenseUrl>https://www.tableau.com/pricing</licenseUrl>
+    <licenseUrl>https://www.tableau.com/eula</licenseUrl>
     <bugTrackerUrl>https://www.tableau.com/support/case</bugTrackerUrl>
 	<releaseNotes>https://www.tableau.com/support/releases</releaseNotes>
 	<dependencies>

--- a/automatic/Tableau-Desktop/tools/chocolateyInstall.ps1
+++ b/automatic/Tableau-Desktop/tools/chocolateyInstall.ps1
@@ -6,11 +6,11 @@ $packageArgs = @{
   packageName    = 'Tableau-Desktop'
   unzipLocation  = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
   fileType       = 'exe'
-  url            = $url
-  silentArgs     = '/quiet /norestart ACCEPTEULA=1'
-  validExitCodes = @(0)
+  url64bit       = $url
+  silentArgs     = "/quiet /norestart /LOG `"$($env:TEMP)\Tableau-$($env:chocolateyPackageVersion)-Install.log`" ACCEPTEULA=1"
+  validExitCodes = @(0,3010)
   softwareName   = 'Tableau*'
-  checksum       = $checksum
+  checksum64     = $checksum
   checksumType   = 'sha256'
 }
 

--- a/automatic/Tableau-Desktop/update.ps1
+++ b/automatic/Tableau-Desktop/update.ps1
@@ -8,8 +8,8 @@ $url_part2 = '.exe'
 function global:au_SearchReplace {
     @{
         'tools\ChocolateyInstall.ps1' = @{
-            "(^[$]checksum\s*=\s*)('.*')"   = "`$1'$($Latest.Checksum32)'"
-            "(^[$]url\s*=\s*)('.*')"   = "`$1'$($Latest.Url)'"
+            "(^[$]checksum64\s*=\s*)('.*')"   = "`$1'$($Latest.Checksum64)'"
+            "(^[$]url64bit\s*=\s*)('.*')"   = "`$1'$($Latest.Url64)'"
         }
      }
 }
@@ -29,7 +29,7 @@ function global:au_GetLatest {
 	$url = $url_part1 + $url_version + $url_part2
     
 
-    $Latest = @{ URL = $url; Version = $version }
+    $Latest = @{ URL64 = $url; Version = $version }
     return $Latest
 }
 


### PR DESCRIPTION
Hi.  I somehow missed your Tableau Desktop package and went through the process of building my own.  🙄 

Anyway, I think there is important information to share about installing the Tableau Desktop package that might not make a difference for a single user, but could make a big difference for a large deployment with updates.  Certainly, the changes to the .nuspec won't hurt anything.

I also added installer logging and a "reboot required" error code to the `chocolateyinstall.ps1` file which should only make things easier for sysadmins.

Finally, I think you want to use the `URL64bit` parameter and associated Checksum because Tableau is a 64-bit only application.  It doesn't make any difference to 64-bit machines because they will install 32-bit apps too, but if you leave it as `URL`, then 32-bit machines will attempt to install it and fail without a "controlled" error.  With the `URL64bit` parameter, Chocolatey will stop any 32-bit systems immediately as not compatible and provide an appropriate message.  

Of course, all of this is only my unsolicited suggestion, so take what you want.  😄 
